### PR TITLE
Prevent php exception due to variable assignment

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -130,6 +130,7 @@ class ModuleController extends ActionController
 		}
 		$this->saveState($configuration);
 
+        // Falls back to the default `BE value` ... because a module can only be loaded in BE - context
 		Configuration::initialize(\Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode(), $configuration);
 		$this->populateView($configuration);
 
@@ -193,6 +194,7 @@ class ModuleController extends ActionController
 		}
 		$this->saveState($configuration);
 
+        // Falls back to the default `BE value` ... because a module can only be loaded in BE - context
 		Configuration::initialize(\Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode(), $configuration);
 		$this->populateView($configuration);
 

--- a/Classes/Domain/Repository/Typo3UserRepository.php
+++ b/Classes/Domain/Repository/Typo3UserRepository.php
@@ -422,7 +422,9 @@ class Typo3UserRepository
     public static function setRandomPassword(): string
     {
 		$factory = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Crypto\PasswordHashing\PasswordHashFactory::class);
-		$instance = $factory->getDefaultHashInstance(\Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode());
+		// falls back to `BE`, because there is no info about the TYPO3 mode
+        // does not harm, because it is a random password, which is never needed
+        $instance = $factory->getDefaultHashInstance(\Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode());
         $password = GeneralUtility::makeInstance(Random::class)->generateRandomBytes(16);
 
         return $instance->getHashedPassword($password);

--- a/Classes/Library/Authentication.php
+++ b/Classes/Library/Authentication.php
@@ -873,15 +873,6 @@ class Authentication
     }
 
     /**
-     * @return int
-     */
-    protected static function getCreationUserId(): int
-    {
-        $cruserId = (\Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode() === 'BE' ? ($GLOBALS['BE_USER']->user['uid'] ?? null) : null);
-        return $cruserId ?? 0;
-    }
-
-    /**
      * @return string
      */
     protected static function getGroupTable(): string

--- a/Classes/Library/Authentication.php
+++ b/Classes/Library/Authentication.php
@@ -69,7 +69,7 @@ class Authentication
      */
     public static function initializeConfiguration()
     {
-        if (Configuration::getMode() === 'be') {
+        if (Configuration::getMode() === 'BE') {
             static::$config = Configuration::getBackendConfiguration();
         } else {
             static::$config = Configuration::getFrontendConfiguration();
@@ -880,7 +880,7 @@ class Authentication
         if (isset(static::$authenticationService) && !empty(static::$authenticationService->authInfo['db_groups']['table'])) {
             $groupTable = static::$authenticationService->authInfo['db_groups']['table'];
         } else {
-            if (\Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode() === 'BE') {
+            if (\Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode(static::$authenticationService->authInfo['loginType']) === 'BE') {
                 $groupTable = 'be_groups';
             } else {
                 $groupTable = 'fe_groups';
@@ -903,5 +903,4 @@ class Authentication
         }
         return $logger;
     }
-
 }

--- a/Classes/Library/Authentication.php
+++ b/Classes/Library/Authentication.php
@@ -547,7 +547,6 @@ class Authentication
             $user = Typo3UserRepository::create(static::$authenticationService->authInfo['db_user']['table']);
 
             $user['pid'] = (int)$pid;
-            $user['cruser_id'] = static::getCreationUserId();
             $user['crdate'] = $GLOBALS['EXEC_TIME'];
             $user['tstamp'] = $GLOBALS['EXEC_TIME'];
             $user['username'] = $username;
@@ -589,7 +588,6 @@ class Authentication
             } else {
                 $typo3Group = Typo3GroupRepository::create($table);
                 $typo3Group['pid'] = (int)$pid;
-                $typo3Group['cruser_id'] = static::getCreationUserId();
                 $typo3Group['crdate'] = $GLOBALS['EXEC_TIME'];
                 $typo3Group['tstamp'] = $GLOBALS['EXEC_TIME'];
             }
@@ -631,7 +629,6 @@ class Authentication
             } else {
                 $typo3User = Typo3UserRepository::create($table);
                 $typo3User['pid'] = (int)$pid;
-                $user['cruser_id'] = static::getCreationUserId();
                 $typo3User['crdate'] = $GLOBALS['EXEC_TIME'];
                 $typo3User['tstamp'] = $GLOBALS['EXEC_TIME'];
             }

--- a/Classes/Library/LdapGroup.php
+++ b/Classes/Library/LdapGroup.php
@@ -37,7 +37,7 @@ class LdapGroup
 	 * @return array
 	 */
 	public static function selectFromMembership(
-		array $membership = [],
+		array $membership,
 		$baseDn,
 		$filter,
 		array $attributes = [],

--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -77,8 +77,8 @@ class AuthenticationService extends \TYPO3\CMS\Core\Authentication\Authenticatio
         $user = false;
         $userRecordOrIsValid = false;
         $remoteUser = $this->getRemoteUser();
-        $enableFrontendSso = \Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode() === 'FE' && $this->config['enableFESSO'] && $remoteUser;
-        $enableBackendSso = \Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode() === 'BE' && $this->config['enableBESSO'] && $remoteUser;
+        $enableFrontendSso = \Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode($this->mode) === 'FE' && $this->config['enableFESSO'] && $remoteUser;
+        $enableBackendSso = \Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode($this->mode) === 'BE' && $this->config['enableBESSO'] && $remoteUser;
 
         // This simple check is the key to prevent your log being filled up with warnings
         // due to the AJAX calls to maintain the session active if your configuration forces
@@ -100,7 +100,7 @@ class AuthenticationService extends \TYPO3\CMS\Core\Authentication\Authenticatio
         }
 
         foreach ($configurationRecords as $configurationRecord) {
-            Configuration::initialize(\Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode(), $configurationRecord);
+            Configuration::initialize(\Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode($this->mode), $configurationRecord);
             if (!Configuration::isEnabledForCurrentHost()) {
                 $msg = sprintf(
                     'Configuration record #%s is not enabled for domain %s',
@@ -204,7 +204,7 @@ class AuthenticationService extends \TYPO3\CMS\Core\Authentication\Authenticatio
             return static::STATUS_AUTHENTICATION_FAILURE_CONTINUE;
         }
 
-        if (\Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode() === 'BE') {
+        if (\Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode($this->mode) === 'BE') {
             $status = Configuration::getValue('BEfailsafe')
                 ? static::STATUS_AUTHENTICATION_FAILURE_CONTINUE
                 : static::STATUS_AUTHENTICATION_FAILURE_BREAK;
@@ -213,13 +213,13 @@ class AuthenticationService extends \TYPO3\CMS\Core\Authentication\Authenticatio
         }
 
         $remoteUser = $this->getRemoteUser();
-        $enableFrontendSso = \Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode() === 'FE' && $this->config['enableFESSO'] && $remoteUser;
-        $enableBackendSso = \Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode() === 'BE' && $this->config['enableBESSO'] && $remoteUser;
+        $enableFrontendSso = \Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode($this->mode) === 'FE' && $this->config['enableFESSO'] && $remoteUser;
+        $enableBackendSso = \Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode($this->mode) === 'BE' && $this->config['enableBESSO'] && $remoteUser;
 
         if ((($this->login['uident'] && $this->login['uname']) || $enableFrontendSso || $enableBackendSso) && !empty($user['tx_igldapssoauth_dn'])) {
             if (isset($user['tx_igldapssoauth_from'])) {
                 $status = static::STATUS_AUTHENTICATION_SUCCESS_BREAK;
-            } elseif (\Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode() === 'BE' && Configuration::getValue('BEfailsafe')) {
+            } elseif (\Causal\IgLdapSsoAuth\Utility\Typo3Utility::getTypo3Mode($this->mode) === 'BE' && Configuration::getValue('BEfailsafe')) {
                 return static::STATUS_AUTHENTICATION_FAILURE_CONTINUE;
             } else {
                 // Failed login attempt (wrong password) - write that to the log!

--- a/Classes/Utility/LdapUtility.php
+++ b/Classes/Utility/LdapUtility.php
@@ -210,9 +210,9 @@ class LdapUtility
      */
     public function disconnect()
     {
-        if ($this->connection) {
+        if (isset($this->connection)) {
             @ldap_unbind($this->connection);
-			unset($this->connection);
+            unset($this->connection);
         }
     }
 

--- a/Classes/Utility/Typo3Utility.php
+++ b/Classes/Utility/Typo3Utility.php
@@ -17,14 +17,21 @@ class Typo3Utility
 	 *
 	 * @return string
 	 */
-	public static function getTypo3Mode(): string
+	public static function getTypo3Mode(string $mode = ''): string
 	{
-		if (($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof \Psr\Http\Message\ServerRequestInterface
+
+        if ($mode !== '') {
+            if (str_ends_with($mode, self::FE)) {
+                return self::FE;
+            }
+            return self::BE;
+        }
+
+        if (($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof \Psr\Http\Message\ServerRequestInterface
 			&& \TYPO3\CMS\Core\Http\ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend()
 		) {
 			return self::FE;
 		}
-
 		return self::BE;
 	}
 }

--- a/Classes/ViewHelpers/ConfigurationTableViewHelper.php
+++ b/Classes/ViewHelpers/ConfigurationTableViewHelper.php
@@ -164,7 +164,7 @@ class ConfigurationTableViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abs
             $value = $iconFactory->getIcon($icon, \TYPO3\CMS\Core\Imaging\Icon::SIZE_SMALL, $overlay)->render() . ' ' . htmlspecialchars($value->getTitle());
             $value = str_replace('<img src=', '<img title="' . htmlspecialchars($options['title']) . '" src=', $value);
         } else {
-            $value = htmlspecialchars($value);
+            $value = htmlspecialchars((string)$value);
         }
 
         return sprintf('<td class="%s">%s</td>', $class, $value);

--- a/Configuration/TCA/tx_igldapssoauth_config.php
+++ b/Configuration/TCA/tx_igldapssoauth_config.php
@@ -11,7 +11,6 @@ return [
         'dividers2tabs' => true,
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
-        'cruser_id' => 'cruser_id',
         'delete' => 'deleted',
         'enablecolumns' => [
             'disabled' => 'hidden',

--- a/Documentation/Development/Index.rst
+++ b/Documentation/Development/Index.rst
@@ -40,7 +40,6 @@ through the following code either in :file:`AdditionalConfiguration.php` or in
        'pid' => '0',
        'tstamp' => '1521027046',
        'crdate' => '1521027046',
-       'cruser_id' => '1',
        'deleted' => '0',
        'hidden' => '0',
        'name' => 'Some Name',

--- a/Resources/Private/Templates/Ajax/Search.html
+++ b/Resources/Private/Templates/Ajax/Search.html
@@ -5,7 +5,7 @@
 
 <f:if condition="{status}">
     <h2>
-        <f:translate key="module_search_status"/>
+        <f:translate key="module_search_status" extensionName="ig_ldap_sso_auth"/>
     </h2>
     <ldap:configurationTable data="{status}" humanKeyNames="1"/>
 </f:if>
@@ -13,14 +13,14 @@
 <f:if condition="{preview}">
     <f:then>
         <h2>
-            <f:translate key="module_search_preview"/>
+            <f:translate key="module_search_preview" extensionName="ig_ldap_sso_auth"/>
         </h2>
         <ldap:configurationTable data="{preview}"/>
     </f:then>
 </f:if>
 
 <h2>
-    <f:translate key="module_search_result"/>
+    <f:translate key="module_search_result" extensionName="ig_ldap_sso_auth" />
 </h2>
 <f:if condition="{resultset}">
     <f:then>
@@ -28,7 +28,7 @@
     </f:then>
     <f:else>
         <em>
-            <f:translate key="module_search_noResult"/>
+            <f:translate key="module_search_noResult" extensionName="ig_ldap_sso_auth"/>
         </em>
     </f:else>
 </f:if>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -7,7 +7,6 @@ CREATE TABLE tx_igldapssoauth_config (
 
 	tstamp int(11) DEFAULT '0' NOT NULL,
 	crdate int(11) DEFAULT '0' NOT NULL,
-	cruser_id int(11) DEFAULT '0' NOT NULL,
 	deleted tinyint(4) DEFAULT '0' NOT NULL,
 	hidden tinyint(4) DEFAULT '0' NOT NULL,
 


### PR DESCRIPTION
A default assignment of variables may only occur after the mandatory parameters. Since $membership is always an array (at this point), the default assignment can be removed savely.